### PR TITLE
Fix BasicGroup empty dimensions

### DIFF
--- a/src/main/java/com/ancevt/d2d2/scene/BasicGroup.java
+++ b/src/main/java/com/ancevt/d2d2/scene/BasicGroup.java
@@ -165,6 +165,10 @@ public class BasicGroup extends AbstractNode implements Group {
         float min = MAX_X;
         float max = 0;
 
+        if(children.isEmpty()) {
+            return 0f;
+        }
+
         for (final Node child : children) {
             float x = child.getX();
             float xw = x + child.getWidth();
@@ -180,6 +184,10 @@ public class BasicGroup extends AbstractNode implements Group {
     public float getHeight() {
         float min = MAX_Y;
         float max = 0;
+
+        if(children.isEmpty()) {
+            return 0f;
+        }
 
         for (final Node child : children) {
             float y = child.getY();


### PR DESCRIPTION
## Summary
- handle empty BasicGroup when computing width/height

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b45f137e48327970396d26aa72ab9